### PR TITLE
Order of services and typo in descriptions

### DIFF
--- a/src/services/admin-get-token/admin-get-token.service.js
+++ b/src/services/admin-get-token/admin-get-token.service.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
         description:
 "Endpoint che permette di ottenere un token valido per le \
 richieste successive alla registrazione dell'admin quali:\n\n\
-* __POST /admin/lms/:id/user__\n\n__PS: Se l'admin che richiede \
+* __POST /admin/:idAdmin/lms/:id/user__\n\n__PS: Se l'admin che richiede \
 il token è il superadmin allora tale token permette di richiamare \
 ad esempio:__\n\n* __GET /admin (lista di tutti gli utenti admin)__\n\n\
 Insieme al token vengono restituiti tempo emissione e tempo per la \

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -19,8 +19,8 @@ const adminGetToken = require("./admin-get-token/admin-get-token.service.js");
 // eslint-disable-next-line no-unused-vars
 module.exports = function (app) {
   // admin
-  app.configure(adminGetToken);
   app.configure(admin);
+  app.configure(adminGetToken);
   app.configure(lms);
   app.configure(access);
   app.configure(validatePairing);

--- a/src/services/statements/statements.service.js
+++ b/src/services/statements/statements.service.js
@@ -26,7 +26,7 @@ __Se il tipo di statements supportato dall'LMS è lo SCORM allora verranno \
 standardizzati e inviati sotto forma di SCORM solo gli oggetti dell'array \
 il cui “identifier” equivale a “defaultplayer”.__\n\n \
 __Se il tipo di statements supportato dall'LMS è XAPI ogni oggetto dell'array \
-verrà standardizzato in uno statement XAPI.__\
+verrà standardizzato in uno statement XAPI.__ \
 Tabella mapping dei parameter da usare negli oggetti all'interno dell'array:\n\n \
 \
 | Parameter        | SCORM.core                      |\n \


### PR DESCRIPTION
- Ordered services having "/admin" above "/admin/getToken"
- Fixed underscores not rendered as bold text in description of "/3d-modules/statements"
- Fixed url in description of "/admin/getToken" missing the "idAdmin" parameter